### PR TITLE
Add blending solution to GUI / inference

### DIFF
--- a/inference/inference.py
+++ b/inference/inference.py
@@ -322,26 +322,26 @@ class Inferencer:
                 # Create the blend mask
                 mask = np.ones((tile_height, tile_width), dtype=np.float32)
 
-                # Apply gradients to edges
+                # Apply gradients to edges (handle small tiles properly)
                 if blend_left > 0:
-                    gradient = np.linspace(0, 1, blend_left)
-                    mask[:, :blend_left] = np.minimum(mask[:, :blend_left], gradient)
+                    actual_blend_left = min(blend_left, tile_width)
+                    gradient = np.linspace(0, 1, actual_blend_left)
+                    mask[:, :actual_blend_left] = np.minimum(mask[:, :actual_blend_left], gradient)
 
                 if blend_right > 0:
-                    gradient = np.linspace(1, 0, blend_right)
-                    end_idx = tile_width
-                    start_idx = max(0, end_idx - blend_right)
-                    mask[:, start_idx:end_idx] = np.minimum(mask[:, start_idx:end_idx], gradient[:end_idx-start_idx])
+                    actual_blend_right = min(blend_right, tile_width)
+                    gradient = np.linspace(1, 0, actual_blend_right)
+                    mask[:, -actual_blend_right:] = np.minimum(mask[:, -actual_blend_right:], gradient)
 
                 if blend_top > 0:
-                    gradient = np.linspace(0, 1, blend_top).reshape(-1, 1)
-                    mask[:blend_top, :] = np.minimum(mask[:blend_top, :], gradient)
+                    actual_blend_top = min(blend_top, tile_height)
+                    gradient = np.linspace(0, 1, actual_blend_top).reshape(-1, 1)
+                    mask[:actual_blend_top, :] = np.minimum(mask[:actual_blend_top, :], gradient)
 
                 if blend_bottom > 0:
-                    gradient = np.linspace(1, 0, blend_bottom).reshape(-1, 1)
-                    end_idx = tile_height
-                    start_idx = max(0, end_idx - blend_bottom)
-                    mask[start_idx:end_idx, :] = np.minimum(mask[start_idx:end_idx, :], gradient[:end_idx-start_idx])
+                    actual_blend_bottom = min(blend_bottom, tile_height)
+                    gradient = np.linspace(1, 0, actual_blend_bottom).reshape(-1, 1)
+                    mask[-actual_blend_bottom:, :] = np.minimum(mask[-actual_blend_bottom:, :], gradient)
 
                 # Apply weighted blending (broadcast mask across RGB channels)
                 output_array[y:y_end, x:x_end] += enhanced_array * mask[:, :, np.newaxis]


### PR DESCRIPTION
The Problem

The original implementation (lines 308-324) used a simple cropping approach:
It would crop out half of the overlap region from each tile
Tiles were pasted side-by-side with hard boundaries
This created visible seams where tiles met

The Solution
I implemented weighted feathering/blending (new lines 296-405):
Accumulation Buffers: Instead of directly pasting tiles, I create two arrays:
output_array: Accumulates weighted pixel values
weight_array: Tracks the sum of blend weights for normalization

Linear Gradient Blending: For each tile, I create a blend mask with linear gradients:
Edges that overlap with other tiles fade from 0 to 1 (or 1 to 0)

Only edges that actually overlap with neighboring tiles are feathered
Edge tiles (at image boundaries) don't have blending on their outer edges
Weighted Accumulation: Each tile's pixels are multiplied by the blend mask and added to the accumulation buffer
Normalization: After all tiles are processed, the accumulated values are divided by the total weights to get the final seamless image