### PR TITLE
Disable gpr support

### DIFF
--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -163,8 +163,16 @@ jobs:
         python -c "import torch; print(f'MPS available: {torch.backends.mps.is_available() if hasattr(torch.backends, \"mps\") else False}')"
       shell: bash
 
+    - name: Check GPR support feature flag
+      id: check-gpr
+      run: |
+        GPR_ENABLED=$(python -c "from gui.features import GPR_SUPPORT_ENABLED; print('true' if GPR_SUPPORT_ENABLED else 'false')")
+        echo "gpr_enabled=$GPR_ENABLED" >> $GITHUB_OUTPUT
+        echo "GPR Support Enabled: $GPR_ENABLED"
+      shell: bash
+
     - name: Compile GPR tools (Linux/macOS)
-      if: matrix.os != 'windows-latest'
+      if: matrix.os != 'windows-latest' && steps.check-gpr.outputs.gpr_enabled == 'true'
       run: |
         echo "Compiling GPR tools from source..."
         chmod +x build_scripts/compile_gpr_tools.sh
@@ -173,25 +181,25 @@ jobs:
           echo "FATAL: GPR tools compilation failed"
           exit 1
         fi
-        
+
         # Verify binary exists and is valid
         if [ ! -f "${{ matrix.gpr_binary }}" ]; then
           echo "FATAL: GPR tools binary not found at expected location: ${{ matrix.gpr_binary }}"
           exit 1
         fi
-        
+
         # Check file size to ensure it's not a placeholder
         SIZE=$(stat -f%z "${{ matrix.gpr_binary }}" 2>/dev/null || stat -c%s "${{ matrix.gpr_binary }}")
         if [ "$SIZE" -lt 10000 ]; then
           echo "FATAL: GPR tools binary is too small ($SIZE bytes) - likely corrupted or placeholder"
           exit 1
         fi
-        
+
         echo "SUCCESS: GPR tools binary found and validated"
         ls -la "${{ matrix.gpr_binary }}"
 
     - name: Compile GPR tools (Windows)
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-latest' && steps.check-gpr.outputs.gpr_enabled == 'true'
       shell: cmd
       run: |
         echo Compiling GPR tools from source...
@@ -200,22 +208,27 @@ jobs:
           echo FATAL: GPR tools compilation failed with exit code %ERRORLEVEL%
           exit /b 1
         )
-        
+
         REM Verify the binary exists and is valid
         if not exist "${{ matrix.gpr_binary }}" (
           echo FATAL: GPR tools binary not found at expected location: ${{ matrix.gpr_binary }}
           exit /b 1
         )
-        
+
         REM Check file size to ensure it's not a placeholder
         for %%I in ("${{ matrix.gpr_binary }}") do set SIZE=%%~zI
         if %SIZE% LSS 10000 (
           echo FATAL: GPR tools binary is too small (%SIZE% bytes) - likely corrupted or placeholder
           exit /b 1
         )
-        
+
         echo SUCCESS: GPR tools binary found and validated
         dir "${{ matrix.gpr_binary }}"
+
+    - name: Skip GPR tools (disabled)
+      if: steps.check-gpr.outputs.gpr_enabled == 'false'
+      run: echo "GPR support is disabled - skipping GPR tools compilation"
+      shell: bash
 
     - name: Create placeholder icons
       run: |
@@ -254,6 +267,7 @@ jobs:
         python -c "import os; [print(os.path.join(r, f)) for r, d, files in os.walk('src') for f in sorted(files) if f.endswith('.py')]"
 
     - name: Verify GPR binary exists before PyInstaller
+      if: steps.check-gpr.outputs.gpr_enabled == 'true'
       run: |
         echo "Checking for GPR binary at: ${{ matrix.gpr_binary }}"
         if [ -f "${{ matrix.gpr_binary }}" ]; then

--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -138,6 +138,14 @@ jobs:
         python --version
         pip --version
 
+    - name: Check GPR support feature flag
+      id: check-gpr
+      run: |
+        GPR_ENABLED=$(python -c "from gui.features import GPR_SUPPORT_ENABLED; print('true' if GPR_SUPPORT_ENABLED else 'false')")
+        echo "gpr_enabled=$GPR_ENABLED" >> $GITHUB_OUTPUT
+        echo "GPR Support Enabled: $GPR_ENABLED"
+      shell: bash
+
     - name: Install Python dependencies (Universal GPU/CPU Build)
       run: |
         python -m pip install --upgrade pip
@@ -154,21 +162,19 @@ jobs:
           pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121
         fi
 
-        # Install other dependencies
-        pip install -r requirements_gui.txt
+        # Install other dependencies, excluding rawpy if GPR support is disabled
+        if [ "${{ steps.check-gpr.outputs.gpr_enabled }}" == "true" ]; then
+          echo "Installing all dependencies (GPR support enabled)..."
+          pip install -r requirements_gui.txt
+        else
+          echo "Installing dependencies without rawpy (GPR support disabled)..."
+          grep -v "^rawpy" requirements_gui.txt | pip install -r /dev/stdin
+        fi
 
         # Verify PyTorch installation
         python -c "import torch; print(f'PyTorch {torch.__version__} installed')"
         python -c "import torch; print(f'CUDA available: {torch.cuda.is_available()}')"
         python -c "import torch; print(f'MPS available: {torch.backends.mps.is_available() if hasattr(torch.backends, \"mps\") else False}')"
-      shell: bash
-
-    - name: Check GPR support feature flag
-      id: check-gpr
-      run: |
-        GPR_ENABLED=$(python -c "from gui.features import GPR_SUPPORT_ENABLED; print('true' if GPR_SUPPORT_ENABLED else 'false')")
-        echo "gpr_enabled=$GPR_ENABLED" >> $GITHUB_OUTPUT
-        echo "GPR Support Enabled: $GPR_ENABLED"
       shell: bash
 
     - name: Compile GPR tools (Linux/macOS)

--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -168,7 +168,9 @@ jobs:
           pip install -r requirements_gui.txt
         else
           echo "Installing dependencies without rawpy (GPR support disabled)..."
-          grep -v "^rawpy" requirements_gui.txt | pip install -r /dev/stdin
+          grep -v "^rawpy" requirements_gui.txt > requirements_gui_no_gpr.txt
+          pip install -r requirements_gui_no_gpr.txt
+          rm requirements_gui_no_gpr.txt
         fi
 
         # Verify PyTorch installation

--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: ${{ runner.os }}-pip-universal-${{ hashFiles('**/requirements*.txt') }}
+        key: ${{ runner.os }}-pip-universal-${{ hashFiles('**/requirements*.txt', 'gui/features.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-universal-
           ${{ runner.os }}-pip-
@@ -177,6 +177,17 @@ jobs:
         python -c "import torch; print(f'PyTorch {torch.__version__} installed')"
         python -c "import torch; print(f'CUDA available: {torch.cuda.is_available()}')"
         python -c "import torch; print(f'MPS available: {torch.backends.mps.is_available() if hasattr(torch.backends, \"mps\") else False}')"
+
+        # Verify rawpy exclusion when GPR is disabled
+        if [ "${{ steps.check-gpr.outputs.gpr_enabled }}" == "false" ]; then
+          if python -c "import rawpy" 2>/dev/null; then
+            echo "ERROR: rawpy is installed but GPR support is disabled!"
+            pip uninstall -y rawpy
+            echo "Uninstalled rawpy"
+          else
+            echo "OK: rawpy is not installed (as expected)"
+          fi
+        fi
       shell: bash
 
     - name: Compile GPR tools (Linux/macOS)

--- a/gui/app.py
+++ b/gui/app.py
@@ -82,10 +82,17 @@ def smoke_test():
     """Run smoke tests for CI validation"""
     print(f"Underwater Enhancer v{__version__}")
     print("Running smoke tests...")
-    
-    
+
+    # Import feature flags
+    try:
+        from gui.features import GPR_SUPPORT_ENABLED
+    except ImportError:
+        GPR_SUPPORT_ENABLED = False
+
+    print(f"  GPR Support: {'Enabled' if GPR_SUPPORT_ENABLED else 'Disabled'}")
+
     errors = []
-    
+
     # Test critical imports
     try:
         import torch
@@ -93,7 +100,7 @@ def smoke_test():
     except ImportError as e:
         errors.append(f"PyTorch import failed: {e}")
         print(f"  [FAIL] PyTorch: {e}")
-    
+
     try:
         import cv2
         print("  [OK] OpenCV imported")
@@ -104,35 +111,39 @@ def smoke_test():
         else:
             errors.append(f"OpenCV import failed: {e}")
             print(f"  [FAIL] OpenCV: {e}")
-    
+
     try:
         import customtkinter
         print("  [OK] CustomTkinter imported")
     except ImportError as e:
         errors.append(f"CustomTkinter import failed: {e}")
         print(f"  [FAIL] CustomTkinter: {e}")
-    
+
     try:
         from src.models.unet_autoencoder import UNetAutoencoder
         print("  [OK] Model imported")
     except ImportError as e:
         errors.append(f"Model import failed: {e}")
         print(f"  [FAIL] Model: {e}")
-    
-    try:
-        from src.converters.gpr_converter import GPRConverter
-        print("  [OK] GPR converter imported")
-    except ImportError as e:
-        errors.append(f"GPR converter import failed: {e}")
-        print(f"  [FAIL] GPR converter: {e}")
-    
+
+    # Only test GPR converter if GPR support is enabled
+    if GPR_SUPPORT_ENABLED:
+        try:
+            from src.converters.gpr_converter import GPRConverter
+            print("  [OK] GPR converter imported")
+        except ImportError as e:
+            errors.append(f"GPR converter import failed: {e}")
+            print(f"  [FAIL] GPR converter: {e}")
+    else:
+        print("  [SKIP] GPR converter (disabled)")
+
     try:
         from src.gui.main_window import UnderwaterEnhancerApp
         print("  [OK] GUI imported")
     except ImportError as e:
         errors.append(f"GUI import failed: {e}")
         print(f"  [FAIL] GUI: {e}")
-    
+
     if errors:
         print("\nSmoke test FAILED with errors:")
         for error in errors:

--- a/gui/features.py
+++ b/gui/features.py
@@ -1,0 +1,12 @@
+"""
+Feature flags for the GUI application.
+
+Toggle features on/off to reduce build size or disable functionality.
+"""
+
+# GPR Support - Set to False to disable GPR file support and reduce build size
+# When disabled:
+# - GPR binaries are not bundled with the application
+# - GPR file format is not accepted as input
+# - Build size is reduced significantly
+GPR_SUPPORT_ENABLED = False

--- a/gui/pyinstaller.spec
+++ b/gui/pyinstaller.spec
@@ -164,7 +164,10 @@ a = Analysis(
         'pip',
         # Don't exclude ANY PyTorch or torchvision modules - they're too interdependent
         # Excluding torchvision modules causes operator registration errors
-    ],
+    ] + (
+        # Exclude GPR-related modules when GPR support is disabled
+        ['rawpy', 'src.converters', 'src.converters.gpr_converter'] if not GPR_SUPPORT_ENABLED else []
+    ),
     win_no_prefer_redirects=False,
     win_private_assemblies=False,
     cipher=block_cipher,

--- a/src/converters/__init__.py
+++ b/src/converters/__init__.py
@@ -2,6 +2,14 @@
 Converters package for image format conversion
 """
 
-from .gpr_converter import GPRConverter
+# Conditionally import GPRConverter based on feature flag
+try:
+    from gui.features import GPR_SUPPORT_ENABLED
+except ImportError:
+    GPR_SUPPORT_ENABLED = False
 
-__all__ = ['GPRConverter']
+if GPR_SUPPORT_ENABLED:
+    from .gpr_converter import GPRConverter
+    __all__ = ['GPRConverter']
+else:
+    __all__ = []


### PR DESCRIPTION
In #26 we discussed that the biggest feature here that made the GUI quite large was the support of the GPR image file type. However, since we don't have any plans to use that any longer in the short term, we should disable it for now to reduce the size of the GUI. If needed we can easily re-enable via a feature flag or make a new utility.